### PR TITLE
OSPF type and provider clean up

### DIFF
--- a/lib/puppet/type/ospf.rb
+++ b/lib/puppet/type/ospf.rb
@@ -1,80 +1,57 @@
 Puppet::Type.newtype(:ospf) do
-  @doc = %q{
-    This type provides the capabilities to manage ospf router within puppet.
-
-      Examples:
-
-        ospf { 'ospf':
-            ensure    => present,
-            abr_type  => cisco,
-            opaque    => true,
-            rfc1583   => true,
-            router_id => '192.168.0.1',
-        }
-  }
+  @doc = 'This type provides the capabilities to manage ospf router within puppet'
 
   ensurable
 
   newparam(:name) do
-    desc %q{ Name must be 'ospf'. }
+    desc 'OSPF router instance. Must be set to \'ospf\''
 
-    newvalues :ospf
+    newvalues(:ospf)
   end
 
   newproperty(:abr_type) do
-    desc %q{ Set OSPF ABR type. Default to `cisco`. }
+    desc 'Set OSPF ABR type. Default to `cisco`.'
 
-    newvalues :cisco, :ibm, :shortcut, :standard
-    defaultto :cisco
-
-    munge do |value|
-      case value
-        when String
-          value.to_sym
-        else
-          value
-      end
-    end
+    newvalues(:cisco, :ibm, :shortcut, :standard)
+    defaultto(:cisco)
   end
 
   newproperty(:opaque, :boolean => true) do
-    desc %q{ Enable the Opaque-LSA capability (rfc2370). Default to `disabled`. }
+    desc 'Enable the Opaque-LSA capability (rfc2370). Default to `false`.'
 
     defaultto(:false)
-    newvalues(:false, :true)
+    newvalues(:true, :false)
   end
 
   newproperty(:rfc1583, :boolean => true) do
-    desc %q{ Enable the RFC1583Compatibility flag. Default to `disabled`. }
+    desc 'Enable the RFC1583Compatibility flag. Default to `false`.'
 
     defaultto(:false)
-    newvalues(:false, :true)
+    newvalues(:true, :false)
   end
 
   newproperty(:router_id) do
-    desc %q{ Router-id for the OSPF process. }
+    desc 'OSPF process router id'
 
     block = /\d{,2}|1\d{2}|2[0-4]\d|25[0-5]/
     re = /\A#{block}\.#{block}\.#{block}\.#{block}\Z/
 
-    newvalues(re)
+    newvalues(:absent, re)
+    defaultto(:absent)
+  end
+
+  newproperty(:log_adjacency_changes) do
+    desc 'Log changes in adjacency'
+
+    defaultto(:false)
+    newvalues(:true, :false, :detail)
   end
 
   autorequire(:package) do
-    case value(:provider)
-      when :quagga
-        %w{quagga}
-      else
-        []
-    end
+    ['quagga']
   end
 
   autorequire(:service) do
-    case value(:provider)
-      when :quagga
-        %w{zebra ospfd}
-      else
-        []
-    end
+    ['zebra', 'ospfd']
   end
 end

--- a/spec/unit/provider/ospf/quagga_spec.rb
+++ b/spec/unit/provider/ospf/quagga_spec.rb
@@ -47,9 +47,9 @@ ip prefix-list CONNECTED-NETWORKS seq 20 permit 195.131.0.0/28 le 32'
         :ensure => :present,
         :name => :ospf,
         :opaque => :false,
-        :provider => :quagga,
         :rfc1583 => :false,
         :router_id => '10.255.78.4',
+        :log_adjacency_changes => :false
       })
     end
   end

--- a/spec/unit/type/ospf_spec.rb
+++ b/spec/unit/type/ospf_spec.rb
@@ -28,10 +28,20 @@ describe Puppet::Type.type(:ospf) do
       end
     end
 
-    [:abr_type, :opaque, :rfc1583, :router_id, ].each do |property|
+    [:abr_type, :opaque, :rfc1583, :router_id, :log_adjacency_changes].each do |property|
       it "should have a #{property} property" do
         expect(described_class.attrtype(property)).to eq(:property)
       end
+    end
+  end
+
+  describe 'name' do
+    it 'should support ospf as a value' do
+      expect { described_class.new(:name => 'ospf') }.to_not raise_error
+    end
+
+    it 'should not support foo as a value' do
+      expect { described_class.new(:name => 'foo') }.to raise_error(Puppet::Error, /Invalid value/)
     end
   end
 
@@ -69,46 +79,18 @@ describe Puppet::Type.type(:ospf) do
     end
 
     it 'should contain standard' do
-      expect(described_class.new(:name => 'ospf', :abr_type => 'standard')[:abr_type]).to eq(:standard)
+      expect(described_class.new(:name => 'ospf', :abr_type => :standard)[:abr_type]).to eq(:standard)
     end
   end
 
   [:opaque, :rfc1583].each do |property|
     describe "boolean values of the property `#{property}`" do
-      it 'should support \'true\' as a value' do
-        expect { described_class.new(:name => 'ospf', property => 'true') }.to_not raise_error
-      end
-
-      it 'should support :true as a value' do
-        expect { described_class.new(:name => 'ospf', property => :true) }.to_not raise_error
-      end
-
       it 'should support true as a value' do
         expect { described_class.new(:name => 'ospf', property => true) }.to_not raise_error
       end
 
-      it 'should support \'false\' as a value' do
-        expect { described_class.new(:name => 'ospf', property => 'false') }.to_not raise_error
-      end
-
-      it 'should support :false as a value' do
-        expect { described_class.new(:name => 'ospf', property => :false) }.to_not raise_error
-      end
-
       it 'should support false as a value' do
         expect { described_class.new(:name => 'ospf', property => false) }.to_not raise_error
-      end
-
-      it 'should not support :enabled as a value' do
-        expect { described_class.new(:name => 'ospf', property => :enabled) }.to raise_error(Puppet::Error, /Invalid value/)
-      end
-
-      it 'should not support \'disabled\' as a value' do
-        expect { described_class.new(:name => 'ospf', property => 'disabled') }.to raise_error(Puppet::Error, /Invalid value/)
-      end
-
-      it 'should contain :true' do
-        expect(described_class.new(:name => 'ospf', property => 'true')[property]).to eq(:true)
       end
 
       it 'should contain :true' do
@@ -116,11 +98,11 @@ describe Puppet::Type.type(:ospf) do
       end
 
       it 'should contain :false' do
-        expect(described_class.new(:name => 'ospf', property => 'false')[property]).to eq(:false)
+        expect(described_class.new(:name => 'ospf', property => false)[property]).to eq(:false)
       end
 
-      it 'should contain :false' do
-        expect(described_class.new(:name => 'ospf', property => false)[property]).to eq(:false)
+      it 'should not support foo as a value' do
+        expect { described_class.new(:name => 'ospf', property => :foo) }.to raise_error(Puppet::Error, /Invalid value/)
       end
     end
   end
@@ -148,6 +130,36 @@ describe Puppet::Type.type(:ospf) do
 
     it 'should contain \'1.1.1.1\'' do
       expect(described_class.new(:name => 'ospf', :router_id => '1.1.1.1')[:router_id]).to eq('1.1.1.1')
+    end
+  end
+
+  describe 'log_adjacency_changes' do
+    it 'should support true as a value' do
+      expect { described_class.new(:name => 'ospf', :log_adjacency_changes => true) }.to_not raise_error
+    end
+
+    it 'should support false as a value' do
+      expect { described_class.new(:name => 'ospf', :log_adjacency_changes => false) }.to_not raise_error
+    end
+
+    it 'should support detail as a value' do
+      expect { described_class.new(:name => 'ospf', :log_adjacency_changes => :detail) }.to_not raise_error
+    end
+
+    it 'should contain :true' do
+      expect(described_class.new(:name => 'ospf', property => true)[:log_adjacency_changes]).to eq(:true)
+    end
+
+    it 'should contain :false' do
+      expect(described_class.new(:name => 'ospf', property => false)[:log_adjacency_changes]).to eq(:false)
+    end
+
+    it 'should contain :detail' do
+      expect(described_class.new(:name => 'ospf', property => :detail)[:log_adjacency_changes]).to eq(:detail)
+    end
+
+    it 'should not support foo as a value' do
+      expect { described_class.new(:name => 'ospf', :log_adjacency_changes => :foo) }.to raise_error(Puppet::Error, /Invalid value/)
     end
   end
 end

--- a/spec/unit/type/ospf_spec.rb
+++ b/spec/unit/type/ospf_spec.rb
@@ -147,15 +147,15 @@ describe Puppet::Type.type(:ospf) do
     end
 
     it 'should contain :true' do
-      expect(described_class.new(:name => 'ospf', property => true)[:log_adjacency_changes]).to eq(:true)
+      expect(described_class.new(:name => 'ospf', :log_adjacency_changes => true)[:log_adjacency_changes]).to eq(:true)
     end
 
     it 'should contain :false' do
-      expect(described_class.new(:name => 'ospf', property => false)[:log_adjacency_changes]).to eq(:false)
+      expect(described_class.new(:name => 'ospf', :log_adjacency_changes => false)[:log_adjacency_changes]).to eq(:false)
     end
 
     it 'should contain :detail' do
-      expect(described_class.new(:name => 'ospf', property => :detail)[:log_adjacency_changes]).to eq(:detail)
+      expect(described_class.new(:name => 'ospf', :log_adjacency_changes => :detail)[:log_adjacency_changes]).to eq(:detail)
     end
 
     it 'should not support foo as a value' do


### PR DESCRIPTION
* re-factored purge in ospf provider. It was silently removing parameters when they were not specified (e.g. router-id).
* cleaned up ospf type and provider
* added log-adjacency-changes parameter to ospf type