### PR TITLE
Adding OSPF stub and auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,8 @@ quagga_ospf_area { '0.0.0.0':
 - `prefix_list_export`: Filter networks sent from this area.
 - `prefix_list_import`: Filter networks sent to this area.
 - `networks`: Enable routing on an IP network. Default value: `[]`.
+- `auth`: Enable authentication on this area: `false`, `true`, `message-digest`. Default value: `false`.
+- `stub`: . Configure the area to be a stub area: `false`, `true`, `no-summary`. Default value: `false`.
 
 #### quagga_prefix_list
 

--- a/README.md
+++ b/README.md
@@ -481,11 +481,13 @@ quagga_interface { 'eth0':
 - `igmp_query_max_response_time_dsec`: IGMP maximum query response time in deciseconds. Default value: `100`.
 - `ipaddress`: IP addresses. Default value: `[]`.
 - `multicast`: Enable multicast flag for the interface. Default value: `false`.
-- `ospf_cost`: Interface cos. Default value: `10`.
+- `ospf_auth`: Interface authentication type: `absent`, `message-digest` . Default value: `absent`.
+- `ospf_message_digest_key`: Set OSPF authentication key to a cryptographic password: `absent`, `KEYID md5 KEY` . Default value: `absent`.
+- `ospf_cost`: Interface cost. Default value: `absent`.
 - `ospf_dead_interval`: Interval after which a neighbor is declared dead. Default value: `40`.
 - `ospf_hello_interval`: Time between HELLO packets. Default value: `10`.
 - `ospf_mtu_ignore`: Disable mtu mismatch detection. Default value: `false`.
-- `ospf_network`: Network type: `broadcast`, `non-broadcast`, `point-to-multipoint`,`point-to-point` or `loopback`. Default value: `broadcast`.
+- `ospf_network`: Network type: `absent`, `broadcast`, `non-broadcast`, `point-to-multipoint`,`point-to-point` or `loopback`. Default value: `absent`.
 - `ospf_priority`: Router priority. Default value: `1`.
 - `ospf_retransmit_interval`: Time between retransmitting lost link state advertisements. Default value: `5`.
 - `ospf_transmit_delay`: Link state transmit delay. Default value: `1`.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -82,5 +82,6 @@ quagga::ospf::service_enable: true
 quagga::ospf::service_manage: true
 quagga::ospf::service_ensure: "running"
 quagga::ospf::service_opts: "-P 0"
-quagga::ospf::router: {}
+quagga::ospf::router:
+  router_id: "%{::facts.networking.ip}"
 quagga::ospf::areas: {}

--- a/lib/puppet/provider/quagga_interface/quagga.rb
+++ b/lib/puppet/provider/quagga_interface/quagga.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:quagga_interface).provide :quagga do
       :regexp => /\A\sip\sospf\snetwork\s([\w-]+)\Z/,
       :template => 'ip ospf network<% unless value.nil? %> <%= value %><% end %>',
       :type => :string,
-      :default => 'broadcast'
+      :default => :absent
     },
     :ospf_priority => {
       :regexp => /\A\sip\sospf\spriority\s(\d+)\Z/,
@@ -182,8 +182,8 @@ Puppet::Type.type(:quagga_interface).provide :quagga do
                 when :boolean
                   interface[property] = :true
 
-                when :symbol
-                  interface[property] = value.gsub(/-/, '_').to_sym
+                else
+                  interface[property] = value
 
               end
             end

--- a/lib/puppet/provider/quagga_interface/quagga.rb
+++ b/lib/puppet/provider/quagga_interface/quagga.rb
@@ -56,11 +56,23 @@ Puppet::Type.type(:quagga_interface).provide :quagga do
       :type => :fixnum,
       :default => 100
     },
+    :ospf_auth => {
+      :regexp => /\A\sip\sospf\sauthentication\s(message-digest)\Z/,
+      :template => 'ip ospf authentication<% unless value.nil? %> <%= value %><% end %>',
+      :type => :string,
+      :default => :absent
+    },
+    :ospf_message_digest_key => {
+      :regexp => /\A\sip\sospf\smessage-digest-key\s(.*)\Z/,
+      :template => 'ip ospf message-digest-key<% unless value.nil? %> <%= value %><% end %>',
+      :type => :string,
+      :default => :absent
+    },
     :ospf_cost => {
       :regexp => /\A\sip\sospf\scost\s(\d+)\Z/,
       :template => 'ip ospf cost<% unless value.nil? %> <%= value %><% end %>',
       :type => :fixnum,
-      :default => 10
+      :default => :absent
     },
     :ospf_dead_interval => {
       :regexp => /\A\sip\sospf\sdead-interval\s(\d+)\Z/,

--- a/lib/puppet/type/quagga_interface.rb
+++ b/lib/puppet/type/quagga_interface.rb
@@ -196,8 +196,8 @@ Puppet::Type.newtype(:quagga_interface) do
   newproperty(:ospf_network) do
     desc 'OSPF network type'
 
-    newvalues(/\A(broadcast|non-broadcast|point-to-multipoint|point-to-point|loopback)\Z/)
-    defaultto('broadcast')
+    newvalues(:absent, :broadcast, 'non-broadcast', 'point-to-multipoint', 'point-to-point', :loopback)
+    defaultto(:absent)
   end
 
   newproperty(:ospf_priority) do

--- a/lib/puppet/type/quagga_interface.rb
+++ b/lib/puppet/type/quagga_interface.rb
@@ -137,15 +137,31 @@ Puppet::Type.newtype(:quagga_interface) do
     defaultto(100)
   end
 
+  newproperty(:ospf_auth) do
+    desc 'Interface OSPF authentication'
+
+    defaultto(:absent)
+    newvalues(:absent, 'message-digest')
+  end
+
+  newproperty(:ospf_message_digest_key) do
+    desc 'Set OSPF authentication key to a cryptographic password. The cryptographic algorithm is MD5.'
+
+    defaultto(:absent)
+    newvalues(:absent, /\d+\smd5\s\S{1,16}/)
+  end
+
   newproperty(:ospf_cost) do
     desc 'Interface OSPF cost'
 
     validate do |value|
-      fail "OSPF cost '#{value}' is not an Integer" unless value.is_a?(Integer)
-      fail "OSPF cost '#{value}' must be between 1-65535" unless value >= 1 and value <= 65535
+      if value != :absent
+        fail "OSPF cost '#{value}' is not an Integer" unless value.is_a?(Integer)
+        fail "OSPF cost '#{value}' must be between 1-65535" unless value >= 1 and value <= 65535
+      end
     end
 
-    defaultto(10)
+    defaultto(:absent)
   end
 
   newproperty(:ospf_dead_interval) do

--- a/lib/puppet/type/quagga_ospf_area.rb
+++ b/lib/puppet/type/quagga_ospf_area.rb
@@ -5,6 +5,8 @@ Puppet::Type.newtype(:quagga_ospf_area) do
       Examples:
 
         ospf_area { '0.0.0.0':
+            auth               => true,
+            stub               => true,
             access_list_export => 'ACCESS_LIST_EXPORT',
             access_list_import => 'ACCESS_LIST_IPMORT',
             prefix_list_export => 'PREFIX_LIST_EXPORT',
@@ -22,6 +24,20 @@ Puppet::Type.newtype(:quagga_ospf_area) do
     re = /\A#{block}\.#{block}\.#{block}\.#{block}\Z/
 
     newvalues(re)
+  end
+
+  newproperty(:auth) do
+    desc %q{OSPF authentication}
+
+    defaultto(:false)
+    newvalues(:false, :true, 'message-digest')
+  end
+
+  newproperty(:stub) do
+    desc %q{Configure the OSPF area to be a stub area}
+
+    defaultto(:false)
+    newvalues(:false, :true, 'no-summary')
   end
 
   newproperty(:access_list_export) do

--- a/spec/unit/provider/quagga_interface/quagga_spec.rb
+++ b/spec/unit/provider/quagga_interface/quagga_spec.rb
@@ -28,6 +28,7 @@ interface eth1
  ip ospf priority 50
  ip ospf retransmit-interval 4
  ip ospf mtu-ignore
+ ip ospf network broadcast
  ip pim ssm
  ip igmp
  ip igmp query-interval 150
@@ -67,7 +68,7 @@ interface tun0
         :ospf_dead_interval => 40,
         :ospf_hello_interval => 10,
         :ospf_mtu_ignore => :false,
-        :ospf_network => 'broadcast',
+        :ospf_network => :absent,
         :ospf_priority => 1,
         :ospf_retransmit_interval => 5,
         :ospf_transmit_delay => 1,
@@ -95,7 +96,7 @@ interface tun0
         :ospf_dead_interval => 8,
         :ospf_hello_interval => 2,
         :ospf_mtu_ignore => :true,
-        :ospf_network => 'broadcast',
+        :ospf_network => :broadcast,
         :ospf_priority => 50,
         :ospf_retransmit_interval => 4,
         :ospf_transmit_delay => 1,

--- a/spec/unit/provider/quagga_interface/quagga_spec.rb
+++ b/spec/unit/provider/quagga_interface/quagga_spec.rb
@@ -20,6 +20,9 @@ describe Puppet::Type.type(:quagga_interface).provider(:quagga) do
       ).returns 'interface eth0
 !
 interface eth1
+ ip ospf authentication message-digest
+ ip ospf message-digest-key 1 md5 hello123
+ ip ospf cost 10
  ip ospf hello-interval 2
  ip ospf dead-interval 8
  ip ospf priority 50
@@ -58,7 +61,7 @@ interface tun0
         :ip_address => [],
         :link_detect => :false,
         :multicast => :false,
-        :ospf_cost => 10,
+        :ospf_cost => :absent,
         :ospf_dead_interval => 40,
         :ospf_hello_interval => 10,
         :ospf_mtu_ignore => :false,
@@ -84,6 +87,8 @@ interface tun0
         :ip_address => [],
         :link_detect => :false,
         :multicast => :false,
+        :ospf_auth => 'message-digest',
+        :ospf_message_digest_key => '1 md5 hello123',
         :ospf_cost => 10,
         :ospf_dead_interval => 8,
         :ospf_hello_interval => 2,

--- a/spec/unit/provider/quagga_interface/quagga_spec.rb
+++ b/spec/unit/provider/quagga_interface/quagga_spec.rb
@@ -96,7 +96,7 @@ interface tun0
         :ospf_dead_interval => 8,
         :ospf_hello_interval => 2,
         :ospf_mtu_ignore => :true,
-        :ospf_network => :broadcast,
+        :ospf_network => 'broadcast',
         :ospf_priority => 50,
         :ospf_retransmit_interval => 4,
         :ospf_transmit_delay => 1,

--- a/spec/unit/provider/quagga_interface/quagga_spec.rb
+++ b/spec/unit/provider/quagga_interface/quagga_spec.rb
@@ -61,6 +61,8 @@ interface tun0
         :ip_address => [],
         :link_detect => :false,
         :multicast => :false,
+        :ospf_auth => :absent,
+        :ospf_message_digest_key => :absent,
         :ospf_cost => :absent,
         :ospf_dead_interval => 40,
         :ospf_hello_interval => 10,

--- a/spec/unit/provider/quagga_ospf_area/quagga_spec.rb
+++ b/spec/unit/provider/quagga_ospf_area/quagga_spec.rb
@@ -53,7 +53,8 @@ router ospf
  area 0.10.10.10 import-list ACCESS_LIST_IPMORT
  area 0.10.10.10 filter-list prefix PREFIX_LIST_IMPORT in
  area 0.10.10.10 filter-list prefix PREFIX_LIST_EXPORT out
- area 0.10.10.10 stub
+ area 0.10.10.10 stub no-summary
+ area 0.10.10.10 authentication message-digest
  default-information originate always metric 100 metric-type 1 route-map ABCD
  ospf router-id 10.255.78.4
  redistribute kernel route-map KERNEL
@@ -85,6 +86,8 @@ ip prefix-list CONNECTED-NETWORKS seq 20 permit 195.131.0.0/28 le 32'
         :networks => %w{10.255.1.0/24 10.255.2.0/24 10.255.3.0/24},
         :prefix_list_export => :absent,
         :prefix_list_import => :absent,
+        :auth => :false,
+        :stub => :false,
         :provider => :quagga,
       })
     end
@@ -98,6 +101,8 @@ ip prefix-list CONNECTED-NETWORKS seq 20 permit 195.131.0.0/28 le 32'
         :networks => %w{192.168.1.0/24 192.168.2.0/24},
         :prefix_list_export => 'PREFIX_LIST_EXPORT',
         :prefix_list_import => 'PREFIX_LIST_IMPORT',
+        :auth => 'message-digest',
+        :stub => 'no-summary',
         :provider => :quagga,
       })
     end

--- a/spec/unit/type/quagga_interface_spec.rb
+++ b/spec/unit/type/quagga_interface_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:quagga_interface) do
       end
     end
 
-    [:ospf_cost, :ospf_dead_interval, :ospf_hello_interval, :ospf_mtu_ignore, :ospf_network,
+    [:ospf_auth, :ospf_message_digest_key, :ospf_cost, :ospf_dead_interval, :ospf_hello_interval, :ospf_mtu_ignore, :ospf_network,
      :ospf_priority, :ospf_retransmit_interval, :ospf_transmit_delay,
      :igmp, :pim_ssm, :igmp_query_interval, :igmp_query_max_response_time_dsec,
      :bandwidth, :link_detect, :multicast,
@@ -240,6 +240,10 @@ describe Puppet::Type.type(:quagga_interface) do
 
       it 'should support point-to-point as value' do
         expect { described_class.new(:name => 'foo', :ospf_network => 'point-to-point') }.to_not raise_error
+      end
+
+      it 'should support :absent as value' do
+        expect { described_class.new(:name => 'foo', :ospf_network => :absent) }.to_not raise_error
       end
 
       it 'should contain point-to-point' do

--- a/spec/unit/type/quagga_interface_spec.rb
+++ b/spec/unit/type/quagga_interface_spec.rb
@@ -247,7 +247,7 @@ describe Puppet::Type.type(:quagga_interface) do
       end
 
       it 'should contain point-to-point' do
-        expect(described_class.new(:name => 'foo', :ospf_network => 'point-to-point')[:ospf_network]).to eq('point-to-point')
+        expect(described_class.new(:name => 'foo', :ospf_network => 'point-to-point')[:ospf_network]).to eq(:"point-to-point")
       end
     end
 

--- a/spec/unit/type/quagga_interface_spec.rb
+++ b/spec/unit/type/quagga_interface_spec.rb
@@ -62,7 +62,47 @@ describe Puppet::Type.type(:quagga_interface) do
       end
     end
 
+    describe 'ospf_auth' do
+      it 'should support :absent as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_auth => :absent) }.to_not raise_error
+      end
+
+      it 'should support message-digest as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_auth => "message-digest") }.to_not raise_error
+      end
+
+      it 'should contain :message-digest' do
+        expect(described_class.new(name: 'foo', :ospf_auth => 'message-digest')[:ospf_auth]).to eq(:"message-digest")
+      end
+
+      it 'should not support foo as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_auth => :foo) }.to raise_error(Puppet::Error, /Invalid value/)
+      end
+    end
+
+    describe 'ospf_message_digest_key' do
+      it 'should support :absent as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_message_digest_key => :absent) }.to_not raise_error
+      end
+
+      it 'should support "1 md5 hello123" as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_message_digest_key => "1 md5 hello123") }.to_not raise_error
+      end
+
+      it 'should contain "1 md5 hello123"' do
+        expect(described_class.new(name: 'foo', :ospf_message_digest_key => '1 md5 hello123')[:ospf_message_digest_key]).to eq('1 md5 hello123')
+      end
+
+      it 'should not support foo as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_message_digest_key => :foo) }.to raise_error(Puppet::Error, /Invalid value/)
+      end
+    end
+
     describe 'ospf_cost' do
+      it 'should support :absent as a value' do
+        expect { described_class.new(:name => 'foo', :ospf_cost => :absent) }.to_not raise_error
+      end
+
       it 'should support 100 as a value' do
         expect { described_class.new(:name => 'foo', :ospf_cost => 100) }.to_not raise_error
       end

--- a/spec/unit/type/quagga_ospf_area_spec.rb
+++ b/spec/unit/type/quagga_ospf_area_spec.rb
@@ -56,6 +56,67 @@ describe Puppet::Type.type(:quagga_ospf_area) do
     end
   end
 
+  describe 'auth' do
+    it 'should support true as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :auth => true) }.to_not raise_error
+    end
+
+    it 'should support false as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :auth => false) }.to_not raise_error
+    end
+
+    it 'should support message-digest as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :auth => "message-digest") }.to_not raise_error
+    end
+
+    it 'should contain :true' do
+      expect(described_class.new(name: '0.0.0.0', :auth => true)[:auth]).to eq(:true)
+    end
+
+    it 'should contain :false' do
+      expect(described_class.new(name: '0.0.0.0', :auth => false)[:auth]).to eq(:false)
+    end
+
+    it 'should contain message-digest' do
+      expect(described_class.new(name: '0.0.0.0', :auth => 'message-digest')[:auth]).to eq('message-digest')
+    end
+
+    it 'should not support foo as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :auth => :foo) }.to raise_error(Puppet::Error, /Invalid value/)
+    end
+  end
+
+  describe "stub" do
+    it 'should support true as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :stub => true) }.to_not raise_error
+    end
+
+    it 'should support false as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :stub => false) }.to_not raise_error
+    end
+
+    it 'should support no-summary as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :stub => "no-summary") }.to_not raise_error
+    end
+
+    it 'should contain :true' do
+      expect(described_class.new(name: '0.0.0.0', :stub => true)[:stub]).to eq(:true)
+    end
+
+    it 'should contain :false' do
+      expect(described_class.new(name: '0.0.0.0', :stub => false)[:stub]).to eq(:false)
+    end
+
+    it 'should contain message-digest' do
+      expect(described_class.new(name: '0.0.0.0', :stub => 'no-summary')[:stub]).to eq('no-summary')
+    end
+
+
+    it 'should not support foo as a value' do
+      expect { described_class.new(:name => '0.0.0.0', :stub => :foo) }.to raise_error(Puppet::Error, /Invalid value/)
+    end
+  end
+
   [:access_list_export, :access_list_import, :prefix_list_export, :prefix_list_import].each do |property|
     describe "#{property}" do
       it 'should support LIST-import as a value' do

--- a/spec/unit/type/quagga_ospf_area_spec.rb
+++ b/spec/unit/type/quagga_ospf_area_spec.rb
@@ -77,8 +77,8 @@ describe Puppet::Type.type(:quagga_ospf_area) do
       expect(described_class.new(name: '0.0.0.0', :auth => false)[:auth]).to eq(:false)
     end
 
-    it 'should contain message-digest' do
-      expect(described_class.new(name: '0.0.0.0', :auth => 'message-digest')[:auth]).to eq('message-digest')
+    it 'should contain :message-digest' do
+      expect(described_class.new(name: '0.0.0.0', :auth => 'message-digest')[:auth]).to eq(:"message-digest")
     end
 
     it 'should not support foo as a value' do
@@ -107,8 +107,8 @@ describe Puppet::Type.type(:quagga_ospf_area) do
       expect(described_class.new(name: '0.0.0.0', :stub => false)[:stub]).to eq(:false)
     end
 
-    it 'should contain message-digest' do
-      expect(described_class.new(name: '0.0.0.0', :stub => 'no-summary')[:stub]).to eq('no-summary')
+    it 'should contain :no-summary' do
+      expect(described_class.new(name: '0.0.0.0', :stub => 'no-summary')[:stub]).to eq(:"no-summary")
     end
 
 


### PR DESCRIPTION
This solves #18. I've also cleaned up the OSPF area provider.

I've also added the respective options in the quagga_interface type and provider. As part of the clean-up, I've also made sure that the ospf_cost and ospf_network resource parameters are defaulted to absent.