### PR TITLE
Add default keepalive/holdtime bgp timers to quagga_bgp_router

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ quagga::bgp::router:
   default_ipv4_unicast: false
   import_check: true
   router_id: 10.0.0.1
+  keepalive: 3
+  holdtime: 9
 ```
 
 ### BGP Address Families
@@ -491,6 +493,8 @@ quagga_bgp_router { 'bgp':
     default_local_preference => 100,
     redistribute             => [ 'ospf route-map BGP_FROM_OSPF', ],
     router_id                => '192.168.1.1',
+    keepalive                => 3,
+    holdtime                 => 9,
 }
 ```
 
@@ -502,6 +506,8 @@ quagga_bgp_router { 'bgp':
 - `default_local_preference`: default local preference. Defaults to `100`.
 - `redistribute`: redistribute information from another routing protocol.
 - `router_id`: override configured router identifier.
+- `keepalive`: the default bgp peer keepalive interval. Defaults to `3`.
+- `holdtime`: the default bgp peer holdtime. Defaults to `9`.
 
 #### quagga_bgp_address_family
 

--- a/lib/puppet/type/quagga_bgp_router.rb
+++ b/lib/puppet/type/quagga_bgp_router.rb
@@ -12,6 +12,8 @@ Puppet::Type.newtype(:quagga_bgp_router) do
             default_ipv4_unicast     => false,
             default_local_preference => 100,
             router_id                => '192.168.1.1',
+            keepalive                => 3,
+            holdtime                 => 9,
         }
   }
 
@@ -95,6 +97,30 @@ Puppet::Type.newtype(:quagga_bgp_router) do
     re = /\A#{block}\.#{block}\.#{block}\.#{block}\Z/
 
     newvalues(re)
+  end
+
+  newproperty(:keepalive) do
+    desc 'Default BGP keepalive interval.'
+    defaultto(3)
+
+    validate do |value|
+      fail "Invalid value '#{value}'. It is not an Integer" unless value.is_a?(Integer)
+      fail "Invalid value '#{value}'. Valid values are 0-65535" unless value >= 0 and value <= 65535
+    end
+  end
+
+  newproperty(:holdtime) do
+    desc 'Default BGP holdtime.'
+    defaultto(9)
+
+    validate do |value|
+      fail "Invalid value '#{value}'. It is not an Integer" unless value.is_a?(Integer)
+      fail "Invalid value '#{value}'. Valid values are 0-65535" unless value >= 0 and value <= 65535
+    end
+  end
+
+  validate do
+    fail "keepalive must be 0 or at least three times greater than holdtime" if value(:keepalive) != 0 and value(:keepalive) > value(:holdtime) / 3
   end
 
   autorequire(:package) do

--- a/spec/unit/provider/quagga_bgp_router/quagga_spec.rb
+++ b/spec/unit/provider/quagga_bgp_router/quagga_spec.rb
@@ -24,6 +24,7 @@ router bgp 65000
  bgp graceful-restart stalepath-time 300
  bgp graceful-restart restart-time 300
  bgp network import-check
+ timers bgp 4 12
  network 172.16.32.0/24
  neighbor INTERNAL peer-group
  neighbor INTERNAL remote-as 197888
@@ -65,7 +66,9 @@ router bgp 65000
           default_ipv4_unicast: :false,
           default_local_preference: 100,
           ensure: :present,
+          holdtime: 12,
           import_check: :true,
+          keepalive: 4,
           name: 'bgp',
           provider: :quagga,
           redistribute: [],

--- a/spec/unit/type/quagga_bgp_router_spec.rb
+++ b/spec/unit/type/quagga_bgp_router_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:quagga_bgp_router) do
     end
 
     [:as_number, :import_check, :default_ipv4_unicast, :default_local_preference,
-     :router_id,].each do |property|
+     :router_id, :keepalive, :holdtime].each do |property|
       it "should have a #{property} property" do
         expect(described_class.attrtype(property)).to eq(:property)
       end
@@ -210,6 +210,32 @@ describe Puppet::Type.type(:quagga_bgp_router) do
 
     it 'should contain 1.1.1.1' do
       expect(described_class.new(:name => 'bgp', :router_id => '1.1.1.1')[:router_id]).to eq('1.1.1.1')
+    end
+  end
+
+  describe 'keepalive/holdtime', type: :type do
+    it 'should support 0/0 as a value' do
+      expect { described_class.new(:name => 'bgp', :keepalive => 0, :holdtime => 0) }.to_not raise_error
+    end
+
+    it 'should support 2/6 as a value' do
+      expect { described_class.new(:name => 'bgp', :keepalive => 2, :holdtime => 6) }.to_not raise_error
+    end
+
+    it 'should not support 3/8 as a value' do
+      expect { described_class.new(:name => 'bgp', :keepalive => 3, :holdtime => 8) }.to raise_error(Puppet::Error, /keepalive must be 0/)
+    end
+
+    it 'should default to 3/9' do
+      expect(described_class.new(:name => 'bgp')).to satisfy { |t| t[:keepalive] == 3 && t[:holdtime] == 9 }
+    end
+
+    it 'should contain 0/0' do
+      expect(described_class.new(:name => 'bgp', :keepalive => 0, :holdtime => 0)).to satisfy { |t| t[:keepalive] == 0 && t[:holdtime] == 0 }
+    end
+
+    it 'should contain 2/6' do
+      expect(described_class.new(:name => 'bgp', :keepalive => 2, :holdtime => 6)).to satisfy { |t| t[:keepalive] == 2 && t[:holdtime] == 6 }
     end
   end
 end


### PR DESCRIPTION
This adds two new properties to the `quagga_bgp_router` type, `keepalive` and `holdtime`, that allow specifying the default bgp router peer timer values, e.g.
```
router bgp 12345
 timers bgp <keepalive> <holdtime>
```