### PR TITLE
Update dependencies and puppet versions

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -39,7 +39,6 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/

--- a/.sync.yml
+++ b/.sync.yml
@@ -7,4 +7,4 @@
 # for the default values.
 ---
 spec/spec_helper.rb:
-  mock_with: :mocha
+  mock_with: ":mocha"

--- a/Gemfile
+++ b/Gemfile
@@ -13,25 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
-  gem 'fuubar',                                                  require: false
-  gem 'pry-byebug',                                              require: false
-  gem 'pry-stack_explorer',                                      require: false
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/manifests/prefix_list.pp
+++ b/manifests/prefix_list.pp
@@ -6,7 +6,7 @@
 define quagga::prefix_list (
   Hash $rules = {},
 ) {
-  $rules.reduce( {}) |Hash $rules, Tuple[Integer, Hash] $rule| {
+  $rules.reduce({}) |Hash $rules, Tuple[Integer, Hash] $rule| {
     merge($rules, { "${name} ${rule[0]}" => $rule[1] })
   }.each |String $prefix_list_name, Hash $prefix_list| {
     quagga_prefix_list { $prefix_list_name:

--- a/manifests/route_map.pp
+++ b/manifests/route_map.pp
@@ -6,7 +6,7 @@
 define quagga::route_map (
   Hash $rules = {},
 ) {
-  $rules.reduce( {}) |Hash $rules, Tuple[Integer, Hash] $rule| {
+  $rules.reduce({}) |Hash $rules, Tuple[Integer, Hash] $rule| {
     merge($rules, { "${name} ${rule[0]}" => $rule[1] })
   }.each |String $route_map_name, Hash $route_map| {
     quagga_route_map { $route_map_name:

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "bibigon812-quagga",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": "Dmitriy Yakovlev",
   "summary": "Puppet module to manage Quagga",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
     "pim",
     "zebra"
   ],
-  "pdk-version": "2.5.0",
-  "template-url": "pdk-default#2.5.0",
-  "template-ref": "tags/2.5.0-0-g369d483"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }

--- a/spec/unit/provider/quagga_logging/quagga_spec.rb
+++ b/spec/unit/provider/quagga_logging/quagga_spec.rb
@@ -60,7 +60,7 @@ log facility local7'
       expect(described_class.instances[0].instance_variable_get('@property_hash')).to eq({
                                                                                            ensure: :present,
         provider: :quagga,
-        name: 'file',
+        name: :file,
         filename: '/tmp/file.log',
         level: :warnings,
                                                                                          })
@@ -70,7 +70,7 @@ log facility local7'
       expect(described_class.instances[1].instance_variable_get('@property_hash')).to eq({
                                                                                            ensure: :present,
         provider: :quagga,
-        name: 'stdout',
+        name: :stdout,
         level: :errors,
                                                                                          })
     end
@@ -79,7 +79,7 @@ log facility local7'
       expect(described_class.instances[2].instance_variable_get('@property_hash')).to eq({
                                                                                            ensure: :present,
         provider: :quagga,
-        name: 'syslog',
+        name: :syslog,
         level: :errors,
                                                                                          })
     end


### PR DESCRIPTION
Allow newer versions of puppetlabs-stdlib < 9.0.0

Allow newer versions of Puppet < 8.0.0

Update PDK to version 2.7.1, template to 2.7.4